### PR TITLE
use glob to fuzzy match path to rpm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "debug": "^4.1.1",
     "fs-extra": "^9.0.0",
     "get-folder-size": "^2.0.1",
+    "glob": "^7.1.6",
     "lodash.template": "^4.5.0",
     "parse-author": "^2.0.0",
     "tmp-promise": "^3.0.2",

--- a/src/packager.js
+++ b/src/packager.js
@@ -7,6 +7,7 @@ const exec = promisify(require('child_process').exec)
 const createTemplatedFile = require('./template')
 const sanitizeName = require('./sanitize-name')
 const readMetadata = require('./read-metadata')
+const glob = promisify(require('glob'))
 const tmp = require('tmp-promise')
 const wrap = require('word-wrap')
 const debug = require('debug')
@@ -91,8 +92,9 @@ PackageRPM.prototype.createPackage = async function () {
  */
 PackageRPM.prototype.writePackage = async function () {
   this.logger(`Copying package to ${this.dest}`)
-  const outputPackage = path.join(this.dest, `${this.packageName}-${this.arch}.rpm`)
-  await fs.copy(this.getRPMPath(), outputPackage)
+  const outputPath = path.join(this.dest, `${this.packageName}-${this.arch}.rpm`)
+  const rpmFile = await glob(this.getRPMPattern())
+  await fs.move(rpmFile[0], outputPath)
 }
 
 /**
@@ -173,8 +175,8 @@ PackageRPM.prototype.specPath = function () {
  *
  * this.stagingDir/RPMS
  */
-PackageRPM.prototype.getRPMPath = function () {
-  return path.join(this.stagingDir, 'RPMS', this.arch, `${this.packageName}-1.${this.arch}.rpm`)
+PackageRPM.prototype.getRPMPattern = function () {
+  return path.join(this.stagingDir, 'RPMS', this.arch, '*.rpm')
 }
 
 /**

--- a/test/packager.js
+++ b/test/packager.js
@@ -1,3 +1,6 @@
+const { promisify } = require('util')
+
+const glob = promisify(require('glob'))
 const expect = require('chai').expect
 const fs = require('fs-extra')
 const packager = require('..')
@@ -145,7 +148,8 @@ describe('Packager', function () {
       await pkgRhel.createSpec()
       await pkgRhel.copyApplication()
       await pkgRhel.createPackage()
-      const doesExist = await fs.pathExists(pkgRhel.getRPMPath())
+      const rpmFile = await glob(pkgRhel.getRPMPattern())
+      const doesExist = await fs.pathExists(rpmFile[0])
       // eslint-disable-next-line
       expect(doesExist).to.be.true
     })


### PR DESCRIPTION
<!-- Ticket number and a general summary of your changes in the Title above -->
<!-- e.g. COMPASS-1111: updates ace editor width in agg pipeline view -->

<!--- The following fields are not obligatory. Use your best judgement on what you think is applicable to the work you've done -->

## Description
Uses `glob` to fuzzy match for `*.rpm` in RPMS directory before moving the built
package over to `dest`. 

### Checklist
- [x] New tests and/or benchmarks are included

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Patch (non-breaking change which fixes an issue)