### PR TITLE
fix install script to not mkdir for package name

### DIFF
--- a/resources/spec.ejs
+++ b/resources/spec.ejs
@@ -23,7 +23,7 @@ print('\n\n\n') }
 
 
 %>%install
-mkdir -p %{buildroot}/%{_bindir}/%name
+mkdir -p %{buildroot}/%{_bindir}
 install -m 755 %{name} %{buildroot}/%{_bindir}/%{name}
 
 


### PR DESCRIPTION
<!-- Ticket number and a general summary of your changes in the Title above -->
<!-- e.g. COMPASS-1111: updates ace editor width in agg pipeline view -->

<!--- The following fields are not obligatory. Use your best judgement on what you think is applicable to the work you've done -->

## Description
Change install script from `mkdir -p %{buildroot}/%{_bindir}/%name` to not
include package name since we won't want the package to be nested in an extra
directory in `/bin`.

This means we can execute installed package globally with `packageName` rather
than `/bin/packageName/packageName`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Patch (non-breaking change which fixes an issue)