### PR TITLE
use child_process.execFile() instead of.exec()

### DIFF
--- a/src/packager.js
+++ b/src/packager.js
@@ -3,7 +3,7 @@
 const { promisify } = require('util')
 
 const getDefaultsFromPackageJSON = require('./defaults')
-const exec = promisify(require('child_process').exec)
+const execFile = promisify(require('child_process').execFile)
 const createTemplatedFile = require('./template')
 const sanitizeName = require('./sanitize-name')
 const readMetadata = require('./read-metadata')
@@ -78,7 +78,7 @@ PackageRPM.prototype.createStagingDir = async function () {
  */
 PackageRPM.prototype.createPackage = async function () {
   this.logger(`Creating package at ${this.stagingDir}`)
-  const output = await exec(`rpmbuild -bb ${this.specPath()} --target ${this.arch} --define "_topdir ${this.stagingDir}"`)
+  const output = await execFile('rpmbuild', ['-bb', this.specPath(), '--target', this.arch, '--define', `_topdir ${this.stagingDir}`])
 
   this.logger('rpmbuild output:', output)
 }


### PR DESCRIPTION
<!-- Ticket number and a general summary of your changes in the Title above -->
<!-- e.g. COMPASS-1111: updates ace editor width in agg pipeline view -->

<!--- The following fields are not obligatory. Use your best judgement on what you think is applicable to the work you've done -->

## Description
Since we are using template strings when running `rpmbuild` command, we should
be using `child_process.execFile()` to avoid any security issues in the
future.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Patch (non-breaking change which fixes an issue)